### PR TITLE
add scala-reflect.jar to the classpath

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -117,7 +117,7 @@
 
     <target name="scalac" depends="-compile, check-scalalib, check-scalac">
 	<taskdef resource="scala/tools/ant/antlib.xml"
-	    classpath="tools/scala-compiler.jar:tools/scala-library.jar" />
+	    classpath="tools/scala-compiler.jar:tools/scala-library.jar:tools/scala-reflect.jar" />
 	<scalac force="changed" deprecation="on"
 	    srcdir="${source.absolute.dir}" includes="**/*.scala"
 	    bootclasspathref="project.target.class.path"


### PR DESCRIPTION
Fix for the build error:

```
scalac:

BUILD FAILED
/Users/ppicazo/git/aprsdroid/build.xml:120: The following error occurred while executing this line:
jar:file:/Users/ppicazo/git/aprsdroid/tools/scala-compiler.jar!/scala/tools/ant/antlib.xml:5: taskdef A class needed by class scala.tools.ant.FastScalac cannot be found: scala/reflect/internal/settings/MutableSettings$SettingValue
 using the classloader AntClassLoader[/Users/ppicazo/git/aprsdroid/tools/scala-compiler.jar:/Users/ppicazo/git/aprsdroid/tools/scala-library.jar]

Total time: 3 seconds
```
