### PR TITLE
Certificate import failed, permission denied

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -21,6 +21,7 @@
     <uses-permission android:name="android.permission.BROADCAST_STICKY" />
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.VIBRATE"/>
 


### PR DESCRIPTION
On two Android 4.4.2 devices (Nexus 5 and Nexus 7), I can't import my p12 certificate into APRSdroid 1.2.3. It prompts for my certificate password, which I enter correctly, click OK, and it fails with "permission denied."

I've tried initiating the import from both Dropbox and Astro file manger. Both fail in the same way.

Have file permissions changed in 4.4, breaking APRSdroid's implementation? Or am I initiating the certificate import incorrectly?

```
W/System.err(16804): java.io.FileNotFoundException: /storage/emulated/0/Android/data/com.dropbox.android/files/scratch/radio/KD7LXL.p12: open failed: EACCES (Permission denied)
W/System.err(16804):    at libcore.io.IoBridge.open(IoBridge.java:409)
W/System.err(16804):    at java.io.FileInputStream.<init>(FileInputStream.java:78)
W/System.err(16804):    at java.io.FileInputStream.<init>(FileInputStream.java:105)
W/System.err(16804):    at android.content.ContentResolver.openInputStream(ContentResolver.java:627)
W/System.err(16804):    at org.aprsdroid.app.KeyfileImportActivity.import_key(KeyfileImportActivity.scala:59)
W/System.err(16804):    at org.aprsdroid.app.KeyfileImportActivity$$anon$1.onClick(KeyfileImportActivity.scala:39)
W/System.err(16804):    at com.android.internal.app.AlertController$ButtonHandler.handleMessage(AlertController.java:166)
W/System.err(16804):    at android.os.Handler.dispatchMessage(Handler.java:102)
W/System.err(16804):    at android.os.Looper.loop(Looper.java:136)
W/System.err(16804):    at android.app.ActivityThread.main(ActivityThread.java:5017)
W/System.err(16804):    at java.lang.reflect.Method.invokeNative(Native Method)
W/System.err(16804):    at java.lang.reflect.Method.invoke(Method.java:515)
W/System.err(16804):    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:779)
W/System.err(16804):    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:595)
W/System.err(16804):    at de.robv.android.xposed.XposedBridge.main(XposedBridge.java:126)
W/System.err(16804):    at dalvik.system.NativeStart.main(Native Method)
W/System.err(16804): Caused by: libcore.io.ErrnoException: open failed: EACCES (Permission denied)
W/System.err(16804):    at libcore.io.Posix.open(Native Method)
W/System.err(16804):    at libcore.io.BlockGuardOs.open(BlockGuardOs.java:110)
W/System.err(16804):    at libcore.io.IoBridge.open(IoBridge.java:393)
W/System.err(16804):    ... 15 more
```
