### PR TITLE
Allow the API key to be customized per-environment with local.properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,16 @@ def versionCodeDate() {
 		return new Date().format("yyyyMMdd00").toInteger()
 	}
 }
+
+def mapsApiKey() {
+	Properties properties = new Properties()
+	try {
+		properties.load(project.rootProject.file('local.properties').newDataInputStream())
+	} catch(Exception ex) {}
+	// the default google_maps_key is restricted to ge0rg's signing keys and can't be used by other builds!
+	properties.getProperty('mapsApiKey', "AIzaSyA12R_iI_upYQ33FWnPU_8GlMKrEmjDxiQ")
+}
+
 android {
 	compileSdkVersion 28
 	defaultConfig {
@@ -68,8 +78,7 @@ android {
 		resValue "string", "build_date", "$build_date"
 		resValue "string", "build_version", "$build_version"
 
-		// the google_maps_key is restricted to ge0rg's signing keys and can't be used by other builds!
-		resValue "string", "google_maps_key", "AIzaSyA12R_iI_upYQ33FWnPU_8GlMKrEmjDxiQ"
+		resValue "string", "google_maps_key", mapsApiKey()
 	}
 	useLibrary 'org.apache.http.legacy'
 	compileOptions {


### PR DESCRIPTION
One thing lost in the migration to Gradle was the ability to cleanly specify a per-developer API key for Google Maps. This adds that back in compatible with the old build system's approach. I've also seen mention of a settings.gradle file and that may be a more Gradle approach to this, but I have not looked into it. This, however, has let me make Google Maps work without modifying files in the repo.

It will default to ge0rg's production signing key if it's not included in local.properties