### PR TITLE
Unit Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ android:
     - platform-tools
 
     - build-tools-28.0.3
-    - android-24
+    - android-24  # Need older API for Android ARM as no KVM for x86
     - android-28
 
     - sys-img-x86-android-26
@@ -39,19 +39,13 @@ addons:
 #services:
 #  - xvfb
 
-# Emulator Management: Create, Start and Wait
+# Start emulator early so it's ready when the build is done
 before_install:
-  - env USE_SDK_WRAPPER=y android list avd
-  - env USE_SDK_WRAPPER=y android list sdk
-  - env USE_SDK_WRAPPER=y android list device
-  - env USE_SDK_WRAPPER=y android list target
   - sudo apt-get install -y xvfb
   # Install the rest of tools (e.g. avdmanager)
-  #- yes | sdkmanager tools
-  # Install the system image.
-  #- sdkmanager "system-images;android-24;default;armeabi-v7a"
+  - yes | sdkmanager tools
   - echo no | avdmanager create avd --force --name test --package 'system-images;android-24;default;armeabi-v7a' --abi armeabi-v7a --sdcard 100M
-  - xvfb-run $ANDROID_HOME/tools/emulator -avd test -no-audio -no-window &
+  - xvfb-run $ANDROID_HOME/emulator/emulator -avd test -no-audio -no-window &
 
 before_script:
   - android-wait-for-emulator
@@ -63,5 +57,5 @@ before_script:
 
 script:
   - ./gradlew build
-  - ./gradlew connectedCheck
   - ./gradlew test
+  - ./gradlew connectedCheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: android
-sudo: true
 dist: trusty
 android:
   components:
@@ -30,22 +29,12 @@ cache:
     - $HOME/.gradle/wrapper/
     - $HOME/.android/build-cache
 
-addons:
-  apt:
-    packages:
-      xvfb
-
-# Requires Xenial
-#services:
-#  - xvfb
-
 # Start emulator early so it's ready when the build is done
 before_install:
-  - sudo apt-get install -y xvfb
   # Install the rest of tools (e.g. avdmanager)
   - yes | sdkmanager tools
   - echo no | avdmanager create avd --force --name test --package 'system-images;android-24;default;armeabi-v7a' --abi armeabi-v7a --sdcard 100M
-  - xvfb-run $ANDROID_HOME/emulator/emulator -avd test -no-audio -no-window &
+  - $ANDROID_HOME/emulator/emulator -avd test -no-audio -no-window &
 
 before_script:
   - android-wait-for-emulator

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,25 @@
 language: android
+sudo: true
 dist: trusty
 android:
   components:
+    - tools  # tools needs to be upgraded twice
+    - tools  # https://github.com/travis-ci/travis-ci/issues/6040#issuecomment-219367943
     - tools
     - platform-tools
 
     - build-tools-28.0.3
+    - android-24
     - android-28
 
     - sys-img-x86-android-26
+    - sys-img-armeabi-v7a-android-24
 
   licenses:
     - 'android-sdk-preview-license-52d11cd2'
     - 'android-sdk-license-.+'
 
+# From Travis CI's guide on how to improve Gradle caching
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
@@ -24,4 +30,38 @@ cache:
     - $HOME/.gradle/wrapper/
     - $HOME/.android/build-cache
 
-script: ./gradlew build connectedCheck test
+addons:
+  apt:
+    packages:
+      xvfb
+
+# Requires Xenial
+#services:
+#  - xvfb
+
+# Emulator Management: Create, Start and Wait
+before_install:
+  - env USE_SDK_WRAPPER=y android list avd
+  - env USE_SDK_WRAPPER=y android list sdk
+  - env USE_SDK_WRAPPER=y android list device
+  - env USE_SDK_WRAPPER=y android list target
+  - sudo apt-get install -y xvfb
+  # Install the rest of tools (e.g. avdmanager)
+  #- yes | sdkmanager tools
+  # Install the system image.
+  #- sdkmanager "system-images;android-24;default;armeabi-v7a"
+  - echo no | avdmanager create avd --force --name test --package 'system-images;android-24;default;armeabi-v7a' --abi armeabi-v7a --sdcard 100M
+  - xvfb-run $ANDROID_HOME/tools/emulator -avd test -no-audio -no-window &
+
+before_script:
+  - android-wait-for-emulator
+  # Disable animations
+  - adb shell settings put global window_animation_scale 0 &
+  - adb shell settings put global transition_animation_scale 0 &
+  - adb shell settings put global animator_duration_scale 0 &
+  - adb shell input keyevent 82 &
+
+script:
+  - ./gradlew build
+  - ./gradlew connectedCheck
+  - ./gradlew test

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,5 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
     - $HOME/.android/build-cache
+
+script: ./gradlew build connectedCheck test

--- a/androidTest/java/org/aprsdroid/app/ExampleInstrumentedTest.java
+++ b/androidTest/java/org/aprsdroid/app/ExampleInstrumentedTest.java
@@ -1,0 +1,26 @@
+package org.aprsdroid.app;
+
+import android.content.Context;
+
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+/**
+ * Instrumented test, which will execute on an Android device.
+ *
+ * @see <a href="http://d.android.com/tools/testing">Testing documentation</a>
+ */
+@RunWith(AndroidJUnit4.class)
+public class ExampleInstrumentedTest {
+    @Test
+    public void useAppContext() {
+        // Context of the app under test.
+        Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        assertEquals("org.aprsdroid.app", appContext.getPackageName());
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,16 @@ def versionCodeDate() {
 		return new Date().format("yyyyMMdd00").toInteger()
 	}
 }
+
+def mapsApiKey() {
+	Properties properties = new Properties()
+	try {
+		properties.load(project.rootProject.file('local.properties').newDataInputStream())
+	} catch(Exception ex) {}
+	// the default google_maps_key is restricted to ge0rg's signing keys and can't be used by other builds!
+	properties.getProperty('mapsApiKey', "AIzaSyA12R_iI_upYQ33FWnPU_8GlMKrEmjDxiQ")
+}
+
 android {
 	compileSdkVersion 28
 	defaultConfig {
@@ -68,8 +78,7 @@ android {
 		resValue "string", "build_date", "$build_date"
 		resValue "string", "build_version", "$build_version"
 
-		// the google_maps_key is restricted to ge0rg's signing keys and can't be used by other builds!
-		resValue "string", "google_maps_key", "AIzaSyA12R_iI_upYQ33FWnPU_8GlMKrEmjDxiQ"
+		resValue "string", "google_maps_key", mapsApiKey()
 	}
 	useLibrary 'org.apache.http.legacy'
 	compileOptions {

--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,7 @@ def mapsApiKey() {
 
 android {
 	compileSdkVersion 28
+	buildToolsVersion "28.0.3"
 	defaultConfig {
 		minSdkVersion 14
 		targetSdkVersion 28
@@ -79,6 +80,8 @@ android {
 		resValue "string", "build_version", "$build_version"
 
 		resValue "string", "google_maps_key", mapsApiKey()
+
+		testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 	}
 	useLibrary 'org.apache.http.legacy'
 	compileOptions {
@@ -127,6 +130,12 @@ android {
 			assets.srcDirs = ['assets']
 			jniLibs.srcDirs = ['libs']
 		}
+		androidTest {
+			java.srcDirs = ['androidTest/java']
+		}
+		test {
+			java.srcDirs = ['test/java']
+		}
 	}
 	lintOptions {
 		disable 'MissingTranslation'
@@ -147,4 +156,7 @@ dependencies {
 	implementation 'com.google.maps.android:android-maps-utils:0.5'
 
 	implementation 'com.squareup.okio:okio:2.1.0'
+	androidTestImplementation 'com.android.support.test:runner:1.0.2'
+	androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+	testImplementation 'junit:junit:4.12'
 }

--- a/test/java/org/aprsdroid/app/AprsPacketTests.java
+++ b/test/java/org/aprsdroid/app/AprsPacketTests.java
@@ -1,0 +1,12 @@
+package org.aprsdroid.app;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class AprsPacketTests {
+	@Test
+	public void testBasic() {
+		assertEquals(18403, AprsPacket.passcode("AB1CD"));
+	}
+}


### PR DESCRIPTION
This branch adds in both local unit tests and instrument unit tests to APRSdroid. Getting the Travis CI part of it was the most difficult. They have a rather dated Android SDK and the first part of testing is updating all the tooling to a reasonable version. All unit tests, both local and instrumented can run on Travis CI with a headless emulator. You can also run them locally on file change. Run `./gradlew -t test` in a separate shell for local unit tests and then make a change to a file that will break the test and save. Just change the passcode ID it's expecting in the test and it should fail within seconds. Put it back and it will pass.

For instrument tests, you can run `./gradlew -t connectedCheck`. Change the expected package name in under androidTest/ and save. It's a little slower, but it should be reasonable. I have noticed that making changes to a Scala file seems to take a considerable amount of time to compile, but the Java files seem to do a lot better.