### PR TITLE
Change To Default Recording device, May help with Some devices not ge…

### DIFF
--- a/src/backend/AfskUploader.scala
+++ b/src/backend/AfskUploader.scala
@@ -20,7 +20,7 @@ class AfskUploader(service : AprsService, prefs : PrefsWrapper) extends AprsBack
 	val use_bt = prefs.getAfskBluetooth()
 	val samplerate = if (use_bt) 16000 else 22050
 	val out_type = prefs.getAfskOutput()
-	val in_type = if (use_bt) /*VOICE_CALL*/1 else /*MIC*/1
+	val in_type = /*DEFAULT*/0
 	val output = new Afsk(out_type, samplerate)
 	val aw = new AfskInWrapper(use_hq, this, in_type, samplerate/2) // 8000 / 11025
 


### PR DESCRIPTION
I believe some devices have odd permissions (especially new devices. 
Specifically using VOICE_CALL, though in the code below, we have "if using bt, then use 1 or 1" essentially. 

I think switching to the DEFAULT recording device should alleviate recording issues for at least the Samsung Galaxy line. 

Another option could be UNPROCESSED -- 9. 

I'd be willing to test a compile, but currently I don't have a compile env. 

Example would be Issue #205

Alternatively A selector could be added to to select the audio in device, the same way The output device is selectable. 