### PR TITLE
Fix latitude/longitude when manually setting GPS location

### DIFF
--- a/src/AprsPacket.scala
+++ b/src/AprsPacket.scala
@@ -3,6 +3,8 @@ package org.aprsdroid.app
 import _root_.android.location.Location
 import _root_.net.ab0oo.aprs.parser._
 
+import scala.math.abs
+
 object AprsPacket {
 	val QRG_RE = ".*?(\\d{2,3}[.,]\\d{3,4}).*?".r
 
@@ -72,9 +74,9 @@ object AprsPacket {
 	}
 
 	val  DirectionsLatitude = "NS";
-	val  DirectionsLongitude = "WE";
+	val  DirectionsLongitude = "EW";
 	def formatDMS(coordinate : Float, nesw : String) = {
-		val dms = Location.convert(coordinate, Location.FORMAT_SECONDS).split(":")
+		val dms = Location.convert(abs(coordinate), Location.FORMAT_SECONDS).split(":")
 		val nesw_idx = (coordinate < 0).compare(false)
 		"%2s° %2s' %s\" %s".format(dms(0), dms(1), dms(2), nesw(nesw_idx))
 	}

--- a/src/AprsPacket.scala
+++ b/src/AprsPacket.scala
@@ -71,10 +71,17 @@ object AprsPacket {
 			""
 	}
 
+	val  DirectionsLatitude = "NS";
+	val  DirectionsLongitude = "WE";
 	def formatDMS(coordinate : Float, nesw : String) = {
 		val dms = Location.convert(coordinate, Location.FORMAT_SECONDS).split(":")
 		val nesw_idx = (coordinate < 0).compare(false)
 		"%2s° %2s' %s\" %s".format(dms(0), dms(1), dms(2), nesw(nesw_idx))
+	}
+
+	def formatCoordinates(latitude : Float, longitude : Float) = {
+		(AprsPacket.formatDMS(latitude, DirectionsLatitude),
+		 AprsPacket.formatDMS(longitude, DirectionsLongitude))
 	}
 
 	def parseQrg(comment : String) : String = {

--- a/src/MapMenuHelper.scala
+++ b/src/MapMenuHelper.scala
@@ -174,8 +174,7 @@ trait MapMenuHelper extends UIHelper with OnClickListener {
 
 	def updateCoordinateInfo(lat : Float, lon : Float): Unit = {
 		resultIntent.putExtra("lat", lat).putExtra("lon", lon)
-		val lat_s = AprsPacket.formatDMS(lat, "NS")
-		val lon_s = AprsPacket.formatDMS(lon, "WE")
+		val (lat_s, lon_s) = AprsPacket.formatCoordinates(lat, lon)
 		infoText.setText(lat_s + "\n" + lon_s)
 		accept.setEnabled(true);
 	}


### PR DESCRIPTION
As reported in issue #314, the dialog for manually setting the GPS position was showing incorrect
values for the latitude and longitude. This fix was both developed and tested on the ui-testing
branch I sent in another PR, but I've cherry picked out just the commits needed for this fix for
easier review. With this PR merged in, all unit and user interface tests written so far now pass
on my local machine despite what Github might be reporting.

- Refactored code for formatting DMS coordinate strings for easier testability
- Longitude values were backwards and removed reduntant negative sign
